### PR TITLE
Enrich request/response log messages with meta information

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -13,7 +13,7 @@ type (
 
 	// WrapHandler is an interface for wrapping a Handle with middleware.
 	WrapHandler interface {
-		Wrap(string, string, []Middleware, Handle) httprouter.Handle
+		Wrap(string, string, []Middleware, Handle, MetaFunc) httprouter.Handle
 	}
 
 	// RootHandler is an interface to instantiate a new root handler.
@@ -91,12 +91,14 @@ func NewServiceHandlerFactory(middlewareWrapper MiddlewareWrapper, versionBuilde
 /* ServiceHandlerFactory implementation */
 
 // Wrap wraps the specified Handle with the specified middleware wrappers.
-func (f *serviceHandlerFactoryImpl) Wrap(subsystem, name string, middlewares []Middleware, handle Handle) httprouter.Handle {
+func (f *serviceHandlerFactoryImpl) Wrap(subsystem, name string, middlewares []Middleware, handle Handle,
+	metaFunc MetaFunc) httprouter.Handle {
+
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		h := handle
 
 		for i := 0; i < len(middlewares); i++ {
-			h = f.middlewareWrapper.Wrap(subsystem, name, middlewares[i], h)
+			h = f.middlewareWrapper.Wrap(subsystem, name, middlewares[i], h, metaFunc)
 		}
 		h(NewWrappedResponseWriter(w), r, RouterParams{Params: p})
 	}

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -209,8 +209,8 @@ type mockMiddlewareWrapper struct {
 	sf.MiddlewareWrapper
 }
 
-func (m *mockMiddlewareWrapper) Wrap(subsystem, name string, middleware sf.Middleware, handler sf.Handle) sf.Handle {
-	a := m.Called(subsystem, name, middleware, handler)
+func (m *mockMiddlewareWrapper) Wrap(subsystem, name string, middleware sf.Middleware, handler sf.Handle, metaFunc sf.MetaFunc) sf.Handle {
+	a := m.Called(subsystem, name, middleware, handler, metaFunc)
 	return a.Get(0).(func(sf.WrappedResponseWriter, *http.Request, sf.RouterParams))
 }
 
@@ -233,8 +233,10 @@ type mockServiceHandlerFactory struct {
 	sf.ServiceHandlerFactory
 }
 
-func (m *mockServiceHandlerFactory) Wrap(subsystem, name string, middlewares []sf.Middleware, handle sf.Handle) httprouter.Handle {
-	a := m.Called(subsystem, name, middlewares, handle)
+func (m *mockServiceHandlerFactory) Wrap(subsystem, name string, middlewares []sf.Middleware, handle sf.Handle,
+	metaFunc sf.MetaFunc) httprouter.Handle {
+
+	a := m.Called(subsystem, name, middlewares, handle, metaFunc)
 	return a.Get(0).(httprouter.Handle)
 }
 

--- a/router.go
+++ b/router.go
@@ -10,6 +10,9 @@ type (
 	// Handle is a function signature for the ServiceFoundation handlers
 	Handle func(WrappedResponseWriter, *http.Request, RouterParams)
 
+	// MetaFunc is a function that returns a map containing meta data used to enrich log messages.
+	MetaFunc func(*http.Request, RouterParams) map[string]string
+
 	// RouterParams is a struct that wraps httprouter.Params
 	RouterParams struct {
 		Params httprouter.Params


### PR DESCRIPTION
Added `MetaFunc` parameter to `service.AddRoute()` to enable insertion of request-specific meta information to log messages. This is a breaking change, which will result in a new version.