### PR TITLE
Optional public root handler & updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ func main() {
 	opt.ServiceStateReader = stateReader
 	opt.SetHandlers() // Required to re-bind the state to the ReadinessHandler
 
+	// Use this in case you want to handle the public root endpoint yourself instead of relying 
+	// on the default catch-all handling.
+	opt.UsePublicRootHandler = true
+
 	svc := sf.NewCustomService(opt)
 
 	svc.AddRoute(

--- a/logformatter.go
+++ b/logformatter.go
@@ -23,8 +23,8 @@ type (
 )
 
 var (
-	logEntryMissingLevelError = errors.New("Missing level in log entry")
-	logEntryMissingEventError = errors.New("Missing event in log entry")
+	errLogEntryMissingLevel = errors.New("Missing level in log entry")
+	errLogEntryMissingEvent = errors.New("Missing event in log entry")
 )
 
 /* LogFormatter implementation */
@@ -40,10 +40,10 @@ func (f *logFormatterImpl) Format(entry *logger.Entry) (string, error) {
 	}
 
 	if entry.Level == "" {
-		return "", logEntryMissingLevelError
+		return "", errLogEntryMissingLevel
 	}
 	if entry.Event == "" {
-		return "", logEntryMissingEventError
+		return "", errLogEntryMissingEvent
 	}
 
 	var logEntry flatLogEntry = make(map[string]interface{})


### PR DESCRIPTION
This PR makes the handling of the public root endpoint optional. By default it's still a catch-all, but by making it optional, you can setup your own root handling in your service.

The examples in the readme file were outdated, because they were missing the meta parameter. I've updated them with some comment describing it's intent.