### PR TITLE
PLA-2179 preflight support

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="false">
+    <TaskOptions isEnabled="true">
       <option name="arguments" value="fmt $FilePath$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />
@@ -9,22 +9,17 @@
       <option name="fileExtension" value="go" />
       <option name="immediateSync" value="false" />
       <option name="name" value="go fmt" />
-      <option name="output" value="" />
+      <option name="output" value="$FilePath$" />
       <option name="outputFilters">
-        <array>
-          <FilterInfo>
-            <option name="description" value="" />
-            <option name="name" value="" />
-            <option name="regExp" value="" />
-          </FilterInfo>
-        </array>
+        <array />
       </option>
       <option name="outputFromStdout" value="false" />
       <option name="program" value="$GoExecPath$" />
+      <option name="runOnExternalChanges" value="false" />
       <option name="scopeName" value="Project Files" />
       <option name="trackOnlyRoot" value="true" />
-      <option name="workingDir" value="$FileDir$" />
-      <envs pass-parent-envs="false">
+      <option name="workingDir" value="$ProjectFileDir$" />
+      <envs>
         <env name="GOROOT" value="$GOROOT$" />
         <env name="GOPATH" value="$GOPATH$" />
         <env name="PATH" value="$GoBinDirs$" />
@@ -38,22 +33,17 @@
       <option name="fileExtension" value="go" />
       <option name="immediateSync" value="false" />
       <option name="name" value="goimports" />
-      <option name="output" value="" />
+      <option name="output" value="$FilePath$" />
       <option name="outputFilters">
-        <array>
-          <FilterInfo>
-            <option name="description" value="" />
-            <option name="name" value="" />
-            <option name="regExp" value="" />
-          </FilterInfo>
-        </array>
+        <array />
       </option>
       <option name="outputFromStdout" value="false" />
-      <option name="program" value="$PROJECT_DIR$/../../../../bin/goimports.exe" />
+      <option name="program" value="goimports.exe" />
+      <option name="runOnExternalChanges" value="false" />
       <option name="scopeName" value="Project Files" />
       <option name="trackOnlyRoot" value="true" />
-      <option name="workingDir" value="" />
-      <envs pass-parent-envs="false">
+      <option name="workingDir" value="$ProjectFileDir$" />
+      <envs>
         <env name="GOROOT" value="$GOROOT$" />
         <env name="GOPATH" value="$GOPATH$" />
         <env name="PATH" value="$GoBinDirs$" />

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,104 +2,167 @@
 
 
 [[projects]]
+  digest = "1:fca365d239707c0319526eeb71b75250ede0eaa26c86d8dba78b9720ed965f84"
   name = "github.com/Travix-International/go-metrics"
   packages = ["."]
+  pruneopts = ""
   revision = "fa7d888fbe15b2585786b027f1f6a30e8d9dab81"
   version = "v1.5.1"
 
 [[projects]]
+  digest = "1:fe59a9eb04a7200658e3f40074cd0ba68e8bf39bc7769c05b8d1cffa9d0b55aa"
   name = "github.com/Travix-International/logger"
   packages = ["."]
+  pruneopts = ""
   revision = "509996f71acd7c13931daff8f104ef1552694df9"
   version = "v0.6.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
+  digest = "1:3c818dada3e41bdb0f509f78e6775610f1bb179449ec8c4c86a45fae35460f3f"
   name = "github.com/julienschmidt/httprouter"
   packages = ["."]
+  pruneopts = ""
   revision = "8c199fb6259ffc1af525cc3ad52ee60ba8359669"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:4c23ced97a470b17d9ffd788310502a077b9c1f60221a85563e49696276b4147"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:60aca47f4eeeb972f1b9da7e7db51dee15ff6c59f7b401c1588b8e6771ba15ef"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:e3aa5178be4fc4ae8cdb37d11c02f7490c00450a9f419e6aa84d02d3b47e90d2"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
   revision = "2e54d0b93cba2fd133edc32211dcc32c06ef72ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:d094102bd188af955ab3a94cf78d10fae623f4c6d13bebe0b336ca6a1b2b58a3"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs",
+  ]
+  pruneopts = ""
   revision = "f98634e408857669d61064b283c4cde240622865"
 
 [[projects]]
+  digest = "1:bfc8db90e2676a2fc0d742a536f376044a9b74f2745b2c60d339eb06c6c6988a"
   name = "github.com/rs/cors"
   packages = ["."]
+  pruneopts = ""
   revision = "7af7a1e09ba336d2ea14b1ce73bf693c6837dbf6"
   version = "v1.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:ed7ac53c7d59041f27964d3f04e021b45ecb5f23c842c84d778a7f1fb67e2ce9"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = ""
   revision = "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
 
 [[projects]]
+  digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock"]
+  packages = [
+    "assert",
+    "mock",
+  ]
+  pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
   branch = "master"
+  digest = "1:a9afbcb2b5dacde3889b77124be6abe68477a09c6da3df224cc74f5e180454e6"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = ""
   revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f1935f7c7d409637bd5ef3bd2100002b5abe08bd069ac52ed0713e2652909b0"
+  input-imports = [
+    "github.com/Travix-International/go-metrics",
+    "github.com/Travix-International/logger",
+    "github.com/julienschmidt/httprouter",
+    "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/rs/cors",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
+    "golang.org/x/net/context",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ServiceFoundation enables you to create Web Services containing:
 * Standardized metrics (defaults to go-metrics)
 * Standardized log messages in JSON format
 * Adding route-specific meta fields to log messages
+* Default handling of pre-flight requests
 
 To do:
 - [ ] De-duplicate CORS elements in slices

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ func main() {
 		[]string{"/helloworld"},
 		sf.MethodsForGet,
 		[]sf.Middleware{sf.PanicTo500, sf.CORS, sf.RequestMetrics},
-		func() sf.MetaFunc { return make(map[string]string) },
+		func(r *http.Request, _ sf.RouterParams) map[string]string {
+        		return make(map[string]string)
+        },
 		func(w sf.WrappedResponseWriter, _ *http.Request, _ sf.RouterParams) {
 			w.JSON(http.StatusOK, "hello world!")
 		})
@@ -174,12 +176,12 @@ func main() {
 		[]string{"/helloworld"},
 		sf.MethodsForGet,
 		[]sf.Middleware{sf.PanicTo500, sf.CORS, sf.RequestMetrics},
-		func() sf.MetaFunc { 
+		func(r *http.Request, _ sf.RouterParams) map[string]string {
             // Use a route-specific meta to log additional fields for handling a route request 
             routeMeta := make(map[string]string)
             routeMeta["hello"] = "route"
 			return routeMeta 
-		},
+        },
 		func(w sf.WrappedResponseWriter, _ *http.Request, _ sf.RouterParams) {
 			w.JSON(http.StatusOK, "hello world!")
 		})

--- a/handlers.go
+++ b/handlers.go
@@ -51,6 +51,11 @@ type (
 		NewQuitHandler() Handle
 	}
 
+	// QuitHandler is an interface to instantiate a new quit handler.
+	PreFlightHandler interface {
+		NewPreFlightHandler() Handle
+	}
+
 	// ServiceHandlerFactory is an interface to get access to implemented handlers.
 	ServiceHandlerFactory interface {
 		NewHandlers() *Handlers
@@ -66,6 +71,7 @@ type (
 		VersionHandler   VersionHandler
 		MetricsHandler   MetricsHandler
 		QuitHandler      QuitHandler
+		PreFlightHandler PreFlightHandler
 	}
 
 	serviceHandlerFactoryImpl struct {
@@ -114,6 +120,7 @@ func (f *serviceHandlerFactoryImpl) NewHandlers() *Handlers {
 		HealthHandler:    f,
 		LivenessHandler:  f,
 		ReadinessHandler: f,
+		PreFlightHandler: f,
 	}
 }
 
@@ -175,5 +182,11 @@ func (f *serviceHandlerFactoryImpl) NewVersionHandler() Handle {
 func (f *serviceHandlerFactoryImpl) NewMetricsHandler() Handle {
 	return func(w WrappedResponseWriter, r *http.Request, _ RouterParams) {
 		promhttp.Handler().ServeHTTP(w, r)
+	}
+}
+
+func (f *serviceHandlerFactoryImpl) NewPreFlightHandler() Handle {
+	return func(w WrappedResponseWriter, _ *http.Request, _ RouterParams) {
+		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -198,6 +198,23 @@ func TestServiceHandlerFactoryImpl_CreateQuitHandler(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestServiceHandlerFactoryImpl_CreatePreFlightHandler(t *testing.T) {
+	m := &mockMiddlewareWrapper{}
+	v := &mockVersionBuilder{}
+	exitFn := func(int) {}
+	w := &mockResponseWriter{}
+	ssr := &mockServiceStateReader{}
+	sut := sf.NewServiceHandlerFactory(m, v, ssr, exitFn)
+
+	w.On("WriteHeader", http.StatusOK).Once()
+
+	// Act
+	actual := sut.NewHandlers().PreFlightHandler.NewPreFlightHandler()
+	actual(w, nil, sf.RouterParams{})
+
+	w.AssertExpectations(t)
+}
+
 func TestServiceHandlerFactoryImpl_WrapHandler(t *testing.T) {
 	const subSystem = "my-sub"
 	const name = "my-name"

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -329,6 +329,19 @@ func (m *mockMetricsHandler) NewMetricsHandler() sf.Handle {
 	return a.Get(0).(sf.Handle)
 }
 
+/* sf.PreFlightHandler mock */
+
+type mockPreFlightHandler struct {
+	mock.Mock
+	sf.PreFlightHandler
+}
+
+func (m *mockPreFlightHandler) NewPreFlightHandler() sf.Handle {
+	a := m.Called()
+	return a.Get(0).(sf.Handle)
+}
+
+
 /* sf.ServiceStateReader mock */
 
 type mockServiceStateReader struct {

--- a/service.go
+++ b/service.go
@@ -302,7 +302,7 @@ func (s *serviceImpl) Run(ctx context.Context) {
 }
 
 func (s *serviceImpl) AddRoute(name string, routes []string, methods []string, middlewares []Middleware, metaFunc MetaFunc, handler Handle) {
-	s.addRouteWithMeta(s.publicRouter, publicSubsystem, name, routes, methods, middlewares, metaFunc, handler)
+	s.addRouteWithMetaAndPreFlight(s.publicRouter, publicSubsystem, name, routes, methods, middlewares, metaFunc, handler)
 }
 
 func (s *serviceImpl) addRoute(router *Router, subsystem, name string, routes []string, methods []string, middlewares []Middleware, handler Handle) {
@@ -319,15 +319,26 @@ func (s *serviceImpl) addRoute(router *Router, subsystem, name string, routes []
 	}
 }
 
-func (s *serviceImpl) addRouteWithMeta(router *Router, subsystem, name string, routes []string, methods []string,
+func (s *serviceImpl) addRouteWithMetaAndPreFlight(router *Router, subsystem, name string, routes []string, methods []string,
 	middlewares []Middleware, metaFunc MetaFunc, handler Handle) {
 
 	for _, path := range routes {
 		wrappedHandler := s.wrapHandler.Wrap(subsystem, name, middlewares, handler, metaFunc)
+		preFlightHandled := false
 
 		for _, method := range methods {
 			router.Router.Handle(method, path, wrappedHandler)
+			preFlightHandled = preFlightHandled || method == http.MethodOptions
 		}
+
+		if preFlightHandled {
+			continue
+		}
+
+		preFlightHandler := s.handlers.PreFlightHandler.NewPreFlightHandler()
+		wrappedPreFlightHandler := s.wrapHandler.Wrap(subsystem, fmt.Sprintf("%v-preflight", name),
+			[]Middleware{Counter}, preFlightHandler, metaFunc)
+		router.Router.Handle(http.MethodOptions, path, wrappedPreFlightHandler)
 	}
 }
 


### PR DESCRIPTION
Currently, the handling of pre-flight requests is left to the consumer services themselves. To make it easier for these services I've added default handling of pre-flight requests to the ServiceFoundation. For all custom routes, a special pre-flight handler is handles any requests to that route with the http OPTIONS method. To ensure that pre-flights are measurable, a counter handler is wrapped around it. If the route has CORS as middleware, it is also wrapped around the pre-flight handler.

If the route already contains http.Options as supported method, the default pre-flight handler is not applied. 